### PR TITLE
m8-common: move consumerir from msm8974-common

### DIFF
--- a/m8-common.mk
+++ b/m8-common.mk
@@ -24,6 +24,7 @@ $(call inherit-product, device/htc/msm8974-common/msm8974-common.mk)
 
 # Permissions
 PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.consumerir.xml:system/etc/permissions/android.hardware.consumerir.xml \
     frameworks/native/data/etc/android.hardware.telephony.cdma.xml:system/etc/permissions/android.hardware.telephony.cdma.xml \
     $(LOCAL_PATH)/configs/com.htc.software.market.xml:system/etc/permissions/com.htc.software.market.xml
 


### PR DESCRIPTION
EyeUL doesn't have a IR sensor.

Change-Id: Icd883341ec1a8bec36d24ea131b49b427ce02cb6