### PR TITLE
Revert "sepolicy: Allow batterymanager and batteryproperties services…

### DIFF
--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -1,3 +1,1 @@
-allow platform_app battery_service:service_manager find;
-allow platform_app healthd_service:service_manager find;
 allow platform_app self:netlink_kobject_uevent_socket { bind create read setopt };


### PR DESCRIPTION
… to be found"

 * Now defined in vendor/cm

This reverts commit 0020c8c0cf77eaf1a94d23904065eeb7f53995df.

Change-Id: I7272256d8c33286ce17b71310aab7b415c394b04